### PR TITLE
Fix typo in the doc

### DIFF
--- a/docs/principles.md
+++ b/docs/principles.md
@@ -7,7 +7,7 @@ title: Principles
 
 Inspired by Redux itself, redux-query aims to maintain a small API surface. However, this doesn't mean that redux-query is limited to basic use cases.
 
-redux-query works across several layers of abstraction – the network layer, the Redux action/state layer, and the UI layer. Each of these layers are independent and can be customized to satisfy your use case. Using Angular or Ember? No problem – just don't use react-redux-react. Want to use your favorite network request library? Build a network interface that wraps that library. Need to add extra headers to each of your requests? Add a custom middleware to your Redux store that processes all redux-query actions. Want to implement custom throttling behaviors? It's possible with a custom network interface.
+redux-query works across several layers of abstraction – the network layer, the Redux action/state layer, and the UI layer. Each of these layers are independent and can be customized to satisfy your use case. Using Angular or Ember? No problem – just don't use redux-query-react. Want to use your favorite network request library? Build a network interface that wraps that library. Need to add extra headers to each of your requests? Add a custom middleware to your Redux store that processes all redux-query actions. Want to implement custom throttling behaviors? It's possible with a custom network interface.
 
 ## Encourages best practices
 


### PR DESCRIPTION
In Principles page

> Using Angular or Ember? No problem – just don't use react-redux-react.

It should be redux-query-react instead.